### PR TITLE
Unblock modules and improve guest path resolution

### DIFF
--- a/lib/vagrant-dsc/provisioner.rb
+++ b/lib/vagrant-dsc/provisioner.rb
@@ -160,7 +160,9 @@ module VagrantPlugins
             module_paths: @module_paths.map { |k,v| v }.join(";"),
             mof_path: @config.mof_path,
             configuration_file: @config.configuration_file,
+            configuration_file_path: "#{@config.manifests_path}/#{File.basename @config.configuration_file}",
             configuration_name: @config.configuration_name,
+            manifests_path: @config.manifests_path,
             temp_path: @config.temp_dir,
             parameters: @config.configuration_params.map { |k,v| "#{k}" + (!v.nil? ? " \"#{v}\"": '') }.join(" ")
         })

--- a/lib/vagrant-dsc/templates/runner.ps1.erb
+++ b/lib/vagrant-dsc/templates/runner.ps1.erb
@@ -14,7 +14,7 @@ echo "Adding to path: $absoluteModulePaths"
 $env:PSModulePath="$absoluteModulePaths;${env:PSModulePath}"
 <% end %>
 
-$script = $(Join-Path "<%= options[:temp_path] %>" "<%= options[:configuration_file] %>")
+$script = $(Join-Path "<%= options[:temp_path] %>" "<%= options[:configuration_file_path] %>" -Resolve)
 echo "PSModulePath Configured: ${env:PSModulePath}"
 echo "Running Configuration file: ${script}"
 

--- a/lib/vagrant-dsc/templates/runner.ps1.erb
+++ b/lib/vagrant-dsc/templates/runner.ps1.erb
@@ -12,6 +12,7 @@ $absoluteModulePaths = [string]::Join(";", ("<%= options[:module_paths] %>".Spli
 
 echo "Adding to path: $absoluteModulePaths"
 $env:PSModulePath="$absoluteModulePaths;${env:PSModulePath}"
+("<%= options[:module_paths] %>".Split(";") | ForEach-Object { gci -Recurse  $_ | ForEach-Object { Unblock-File  $_.FullName} })
 <% end %>
 
 $script = $(Join-Path "<%= options[:temp_path] %>" "<%= options[:configuration_file_path] %>" -Resolve)

--- a/lib/vagrant-dsc/templates/runner.ps1.erb
+++ b/lib/vagrant-dsc/templates/runner.ps1.erb
@@ -7,7 +7,7 @@
 #
 
 # Set the local PowerShell Module environment path
-<% if options[:module_paths]  %>
+<% if !options[:module_paths].empty?  %>
 $absoluteModulePaths = [string]::Join(";", ("<%= options[:module_paths] %>".Split(";") | ForEach-Object { $_ | Resolve-Path }))
 
 echo "Adding to path: $absoluteModulePaths"

--- a/spec/provisioner/config_spec.rb
+++ b/spec/provisioner/config_spec.rb
@@ -101,6 +101,11 @@ describe VagrantPlugins::DSC::Config do
       expect(subject.expanded_module_paths('/path/to/vagrant/')).to eq(["/path/to/vagrant/foo/modules"])
     end
 
+    it "should generate a module path on the host machine relative to the Vagrantfile with relative paths" do
+      subject.module_path = "../modules"
+      expect(subject.expanded_module_paths('/path/to/vagrant/')).to eq(["/path/to/modules"])
+    end
+
     it "should generate module paths on the host machine relative to the Vagrantfile" do
       subject.module_path = ["dont/exist", "also/dont/exist"]
       expect(subject.expanded_module_paths('/path/to/vagrant/')).to eq(["/path/to/vagrant/dont/exist", "/path/to/vagrant/also/dont/exist"])

--- a/spec/provisioner/provisioner_spec.rb
+++ b/spec/provisioner/provisioner_spec.rb
@@ -260,6 +260,7 @@ $absoluteModulePaths = [string]::Join(\";\", (\"/tmp/vagrant-dsc-1/modules-0;/tm
 
 echo \"Adding to path: $absoluteModulePaths\"
 $env:PSModulePath=\"$absoluteModulePaths;${env:PSModulePath}\"
+(\"/tmp/vagrant-dsc-1/modules-0;/tmp/vagrant-dsc-1/modules-1\".Split(\";\") | ForEach-Object { gci -Recurse  $_ | ForEach-Object { Unblock-File  $_.FullName} })
 
 $script = $(Join-Path \"/tmp/vagrant-dsc-1\" \"manifests/MyWebsite.ps1\" -Resolve)
 echo \"PSModulePath Configured: ${env:PSModulePath}\"
@@ -300,6 +301,7 @@ $absoluteModulePaths = [string]::Join(\";\", (\"/tmp/vagrant-dsc-1/modules-0;/tm
 
 echo \"Adding to path: $absoluteModulePaths\"
 $env:PSModulePath=\"$absoluteModulePaths;${env:PSModulePath}\"
+(\"/tmp/vagrant-dsc-1/modules-0;/tmp/vagrant-dsc-1/modules-1\".Split(\";\") | ForEach-Object { gci -Recurse  $_ | ForEach-Object { Unblock-File  $_.FullName} })
 
 $script = $(Join-Path \"/tmp/vagrant-dsc-1\" \"../manifests/MyWebsite.ps1\" -Resolve)
 echo \"PSModulePath Configured: ${env:PSModulePath}\"
@@ -339,6 +341,7 @@ $absoluteModulePaths = [string]::Join(\";\", (\"/tmp/vagrant-dsc-1/modules-0;/tm
 
 echo \"Adding to path: $absoluteModulePaths\"
 $env:PSModulePath=\"$absoluteModulePaths;${env:PSModulePath}\"
+(\"/tmp/vagrant-dsc-1/modules-0;/tmp/vagrant-dsc-1/modules-1\".Split(\";\") | ForEach-Object { gci -Recurse  $_ | ForEach-Object { Unblock-File  $_.FullName} })
 
 $script = $(Join-Path \"/tmp/vagrant-dsc-1\" \"manifests/MyWebsite.ps1\" -Resolve)
 echo \"PSModulePath Configured: ${env:PSModulePath}\"
@@ -376,6 +379,7 @@ $absoluteModulePaths = [string]::Join(\";\", (\"/tmp/vagrant-dsc-1/modules-0;/tm
 
 echo \"Adding to path: $absoluteModulePaths\"
 $env:PSModulePath=\"$absoluteModulePaths;${env:PSModulePath}\"
+(\"/tmp/vagrant-dsc-1/modules-0;/tmp/vagrant-dsc-1/modules-1\".Split(\";\") | ForEach-Object { gci -Recurse  $_ | ForEach-Object { Unblock-File  $_.FullName} })
 
 $script = $(Join-Path \"/tmp/vagrant-dsc-1\" \"manifests/MyWebsite.ps1\" -Resolve)
 echo \"PSModulePath Configured: ${env:PSModulePath}\"
@@ -416,6 +420,7 @@ $absoluteModulePaths = [string]::Join(\";\", (\"/tmp/vagrant-dsc-1/modules-0;/tm
 
 echo \"Adding to path: $absoluteModulePaths\"
 $env:PSModulePath=\"$absoluteModulePaths;${env:PSModulePath}\"
+(\"/tmp/vagrant-dsc-1/modules-0;/tmp/vagrant-dsc-1/modules-1\".Split(\";\") | ForEach-Object { gci -Recurse  $_ | ForEach-Object { Unblock-File  $_.FullName} })
 
 $script = $(Join-Path \"/tmp/vagrant-dsc-1\" \"manifests/MyWebsite.ps1\" -Resolve)
 echo \"PSModulePath Configured: ${env:PSModulePath}\"


### PR DESCRIPTION
This PR fixes issues #11 and #12 where path resolution of the main DSC manifest was broken when provided a relative path in `manifests_path` or `configuration_file` (in particular when the path contains a '../' part) or when a `module_path` is not provided.

It improves the process by converting paths to absolute URLs on the guest.

Secondly, it addresses a valid, albeit unlikely scenario, highlighted by the intentions of PR #10, where DSC modules need to be explicitly 'unblocked' before they can be run.

