### PR TITLE
New provisioner parameter 'configuration_data_file'.

### DIFF
--- a/development/Vagrantfile
+++ b/development/Vagrantfile
@@ -6,7 +6,7 @@ $shell_script = <<SCRIPT
   #choco install seek-dsc
   (New-Object System.Net.WebClient).DownloadFile('https://gallery.technet.microsoft.com/scriptcenter/xWebAdministration-Module-3c8bb6be/file/131367/3/xWebAdministration_1.3.2.zip','c:\\xwebadmin.zip')
   choco install 7zip
-  & 'C:\\Program Files\\7-Zip\\7z.exe' x C:\\xwebadmin.zip -o'C:\\Program Files\\WindowsPowerShell\\Modules'
+  7za.exe x -y C:\\xwebadmin.zip -o'C:\\Program Files\\WindowsPowerShell\\Modules'
   Get-DSCResource
 SCRIPT
 
@@ -19,7 +19,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # please see the online documentation at vagrantup.com.
 
   # Every Vagrant virtual environment requires a box to build off of.
-  config.vm.box = "mfellows/windows2012r2"
+  # config.vm.box = "mfellows/windows2012r2"
+  # config.vm.box_version = "1.0.1"
+  config.vm.box = "windows2012r2"
 
   config.vm.guest = :windows
   config.vm.communicator = "winrm"
@@ -53,12 +55,12 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     # The path relative to `dsc.manifests_path` pointing to the Configuration file
     dsc.configuration_file  = "MyWebsite.ps1"
 
+    # The path relative to Vagrantfile pointing to the Configuration Data file
+    dsc.configuration_data_file  = "manifests/MyConfig.psd1"
+
     # The Configuration Command to run. Assumed to be the same as the `dsc.configuration_file`
     # (sans extension) if not provided.
     dsc.configuration_name = "MyWebsite"
-
-    # Commandline arguments to the Configuration run
-    # Set of Parameters to pass to the DSC Configuration.
 
     # Relative path to a pre-generated MOF file.
     #
@@ -70,6 +72,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     #
     # Path is relative to the folder containing the Vagrantfile.
     dsc.manifests_path = "manifests"
+
+    # Commandline arguments to the Configuration run
+    #
+    # Set of Parameters to pass to the DSC Configuration.
     dsc.configuration_params = {"-MachineName" => "localhost"}
 
     # The type of synced folders to use when sharing the data

--- a/development/manifests/MyConfig.psd1
+++ b/development/manifests/MyConfig.psd1
@@ -1,0 +1,10 @@
+@{   
+    AllNodes =
+    @(
+        @{     
+          NodeName = "localhost"; 
+          PSDscAllowPlainTextPassword = $true; 
+          RebootIfNeeded = $True;
+        }
+    )
+} 

--- a/development/manifests/MyWebsite.ps1
+++ b/development/manifests/MyWebsite.ps1
@@ -13,6 +13,12 @@ Configuration MyWebsite
         Name = "Web-Server"
     }
 
+    WindowsFeature IISManagerFeature
+    {
+        Ensure = "Present"
+        Name = "Web-Mgmt-Tools"
+    }    
+
     cFirewallRule webFirewall
     {
         Name = "WebFirewallOpen"

--- a/lib/vagrant-dsc/locales/en.yml
+++ b/lib/vagrant-dsc/locales/en.yml
@@ -30,6 +30,8 @@ en:
         "Path to DSC Manifest folder does not exist: %{path}"
       manifest_missing: |-
         "Path to DSC Manifest does not exist: %{manifest}"
+      configuration_data_missing: |-
+        "Path to DSC Configuration Data file does not exist: %{path}"
       manifest_and_mof_provided: |-
         "Cannot provide configuration_file and mof_path at the same time. Please provide only one of the two."
       unsupported_operation: |-

--- a/lib/vagrant-dsc/provisioner.rb
+++ b/lib/vagrant-dsc/provisioner.rb
@@ -160,6 +160,7 @@ module VagrantPlugins
             module_paths: @module_paths.map { |k,v| v }.join(";"),
             mof_path: @config.mof_path,
             configuration_file: @config.configuration_file,
+            configuration_data_file: @config.expanded_configuration_data_file,
             configuration_file_path: "#{@config.manifests_path}/#{File.basename @config.configuration_file}",
             configuration_name: @config.configuration_name,
             manifests_path: @config.manifests_path,

--- a/lib/vagrant-dsc/templates/runner.ps1.erb
+++ b/lib/vagrant-dsc/templates/runner.ps1.erb
@@ -33,4 +33,5 @@ $StagingPath = "<%= options[:mof_path] %>"
 
 # Start a DSC Configuration run
 $response += Start-DscConfiguration -Force -Wait -Verbose -Path $StagingPath 4>&1 5>&1 | Out-String
+del $StagingPath\*.mof
 $response


### PR DESCRIPTION
Takes a path to the Configuration Data file (https://technet.microsoft.com/en-us/library/dn249925.aspx) relative to the Vagrantfile
that will be passed in to the DSC Runner at runtime.

See Issue #15 for details.