### PR TITLE
Wait for DSC

### DIFF
--- a/development_reboot/Vagrantfile
+++ b/development_reboot/Vagrantfile
@@ -1,0 +1,35 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+$shell_script = <<SCRIPT
+  # config desired state
+  . C:\\vagrant\\manifests\\LCMConfig.ps1
+  LCMConfig
+  Set-DscLocalConfigurationManager -Path ".\\LCMConfig"
+SCRIPT
+
+VAGRANTFILE_API_VERSION = "2"
+
+# linked clone feature requires 1.8
+Vagrant.require_version ">= 1.8" 
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.vm.box = "mwrock/Windows2016"
+  config.vm.guest = :windows
+  config.vm.communicator = "winrm"
+
+  # we do not need, the following config, but gives some convenience
+  config.vm.provider "virtualbox" do |v|
+    # Link clone, get a faster up after destroy
+    v.linked_clone = true
+    # Get the clipboard to interact with host
+    v.customize ["modifyvm", :id, "--clipboard", "bidirectional"]
+  end
+
+  config.vm.provision "shell", inline: $shell_script
+
+  config.vm.provision "dsc" do |dsc|
+    dsc.configuration_file  = "Reboot.ps1"
+    dsc.configuration_name = "Reboot"
+    dsc.manifests_path = "manifests"      
+  end
+end

--- a/development_reboot/manifests/LCMConfig.ps1
+++ b/development_reboot/manifests/LCMConfig.ps1
@@ -1,0 +1,12 @@
+[DSCLocalConfigurationManager()]
+configuration LCMConfig
+{
+    Node localhost
+    {
+        Settings
+        {
+            RebootNodeIfNeeded = $true
+            ActionAfterReboot = "ContinueConfiguration"
+        }
+    }
+}

--- a/development_reboot/manifests/Reboot.ps1
+++ b/development_reboot/manifests/Reboot.ps1
@@ -1,0 +1,30 @@
+Configuration Reboot
+{
+    Import-DscResource -ModuleName 'PSDesiredStateConfiguration'
+    
+    Script Reboot
+    {
+        TestScript = {
+            return (Test-Path HKLM:\SOFTWARE\MyMainKey\RebootKey)
+        }
+        SetScript = {
+            New-Item -Path HKLM:\SOFTWARE\MyMainKey\RebootKey -Force
+                $global:DSCMachineStatus = 1 
+
+        }
+        GetScript = { return @{result = 'result'}}
+    }
+
+    Script Error
+    {
+        TestScript = {
+            throw "This did not work"
+            return $true
+        }
+        SetScript = { 
+
+        }
+        GetScript = { return @{result = 'result'}}
+        DependsOn = "[Script]Reboot"
+    }
+}

--- a/lib/vagrant-dsc/locales/en.yml
+++ b/lib/vagrant-dsc/locales/en.yml
@@ -38,3 +38,5 @@ en:
         "Operation unsupported / not-yet implemented: %{operation}"
       absolute_module_path: |-
         "Absolute 'module_path' not allowed. Please provide a path relative to your Vagrantfile."
+      failure_status: |-
+        "DSC Status is \"Failure\"."

--- a/spec/provisioner/provisioner_spec.rb
+++ b/spec/provisioner/provisioner_spec.rb
@@ -147,6 +147,7 @@ describe VagrantPlugins::DSC::Provisioner do
       allow(subject).to receive(:verify_shared_folders).and_return(true)
       allow(subject).to receive(:verify_dsc).and_return(true)
       allow(subject).to receive(:run_dsc_apply).and_return(true)
+      allow(subject).to receive(:wait_for_dsc_completion) 
       allow(guest).to receive(:capability?).with(:wait_for_reboot).and_return(false)
       expect(guest).to_not receive(:capability).with(:wait_for_reboot)
 
@@ -159,6 +160,7 @@ describe VagrantPlugins::DSC::Provisioner do
       allow(subject).to receive(:verify_shared_folders).and_return(true)
       allow(subject).to receive(:verify_dsc).and_return(true)
       allow(subject).to receive(:run_dsc_apply).and_return(true)
+      allow(subject).to receive(:wait_for_dsc_completion)
       allow(guest).to receive(:capability?)
       allow(guest).to receive(:capability)
 
@@ -174,6 +176,7 @@ describe VagrantPlugins::DSC::Provisioner do
       allow(subject).to receive(:verify_shared_folders).and_return(true)
       allow(subject).to receive(:verify_dsc).and_return(true)
       allow(subject).to receive(:run_dsc_apply).and_return(true)
+      allow(subject).to receive(:wait_for_dsc_completion)
       allow(guest).to receive(:capability?)
       allow(guest).to receive(:capability)
 
@@ -192,6 +195,7 @@ describe VagrantPlugins::DSC::Provisioner do
       allow(communicator).to receive(:upload)
       allow(subject).to receive(:verify_dsc).and_return(true)
       allow(subject).to receive(:run_dsc_apply).and_return(true)
+      allow(subject).to receive(:wait_for_dsc_completion)
       allow(guest).to receive(:capability?)
       allow(guest).to receive(:capability)
 
@@ -221,6 +225,7 @@ describe VagrantPlugins::DSC::Provisioner do
       allow(communicator).to receive(:shell).and_return(shell)
       allow(subject).to receive(:get_lcm_state).and_return("PendingReboot", "Busy", "Sucess")
       allow(subject).to receive(:get_configuration_status).and_return("Sucess")
+      allow(Vagrant::Util::PowerShell).to receive(:version).and_return("5")
       expect(guest).to receive(:capability).with(:wait_for_reboot)
 
       subject.wait_for_dsc_completion
@@ -232,6 +237,7 @@ describe VagrantPlugins::DSC::Provisioner do
       allow(communicator).to receive(:shell).and_return(shell)
       allow(subject).to receive(:get_lcm_state).and_return("PendingReboot", "Busy", "PendingReboot", "Busy", "Idle")
       allow(subject).to receive(:get_configuration_status).and_return("Success")
+      allow(Vagrant::Util::PowerShell).to receive(:version).and_return("5")
       expect(guest).to receive(:capability).twice.with(:wait_for_reboot)
 
       subject.wait_for_dsc_completion
@@ -244,6 +250,7 @@ describe VagrantPlugins::DSC::Provisioner do
       allow(guest).to receive(:capability).with(:wait_for_reboot)
       allow(subject).to receive(:get_lcm_state).and_return("PendingReboot", "Busy", "PendingConfiguration")
       allow(subject).to receive(:get_configuration_status).and_return("Failure")
+      allow(Vagrant::Util::PowerShell).to receive(:version).and_return("5")
       expect(subject).to receive(:show_dsc_failure_message)
 
       subject.wait_for_dsc_completion


### PR DESCRIPTION
I have a vagrant with multi machine setup and required reboots. Therefore I added function that waits until DSC is ready. The cmdlets I used require WMF5. Having the Status allowed the get and show the error message on failure. I added a minimal vagrant file for test purpose in the development_reboot folder.

This is my first vagrant plugin code and ruby has some time since last coding in it. Any advice is welcome.