### PR TITLE
Allow Setup of a domain controller

### DIFF
--- a/lib/vagrant-dsc/locales/en.yml
+++ b/lib/vagrant-dsc/locales/en.yml
@@ -40,3 +40,6 @@ en:
         "Absolute 'module_path' not allowed. Please provide a path relative to your Vagrantfile."
       failure_status: |-
         "DSC Status is \"Failure\"."
+
+    winRMAuthorizationError_recover: |-
+      The Host disconnect the active connection. Try to wait for the completion of DSC.

--- a/lib/vagrant-dsc/provisioner.rb
+++ b/lib/vagrant-dsc/provisioner.rb
@@ -98,8 +98,14 @@ module VagrantPlugins
 
         write_dsc_runner_script(generate_dsc_runner_script)
 
-        run_dsc_apply
-
+        begin
+          run_dsc_apply
+        rescue VagrantPlugins::CommunicatorWinRM::Errors::AuthenticationFailed
+          # when install set a domain controller windows kills the active connection with a AuthenticationFailed.
+          # The DSC job is still running and new connections are possible, so try to wait 
+          @machine.ui.info(I18n.t("vagrant_dsc.winRMAuthorizationError_recover"))
+        end
+        
         wait_for_dsc_completion
       end
 


### PR DESCRIPTION
Setting up a domain controller disconnect the current WinRM Session with
a AuthenticationFailed. So catch this error and resume with the wait for
the DSC completion

The error message was before:
```
An authorization error occurred while connecting to WinRM.

User: vagrant
Endpoint: http://127.0.0.1:55985/wsman
Message: WinRM::WinRMAuthorizationError
```