### PR TITLE
Install Nuget if required for Install-Module

### DIFF
--- a/lib/vagrant-dsc/templates/runner.ps1.erb
+++ b/lib/vagrant-dsc/templates/runner.ps1.erb
@@ -17,6 +17,11 @@ $env:PSModulePath="$absoluteModulePaths;${env:PSModulePath}"
 
 <% if !options[:module_install].empty?  %>
 Write-Host "Ensure Modules"
+Get-PackageProvider -Name NuGet -ListAvailable -ErrorAction SilentlyContinue -ErrorVariable NuGetError | Out-Null
+if ($NuGetError) {
+    Write-Host "Install Package Provider Nuget"
+    Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force | Out-Null
+}
 if ((Get-PSRepository -Name PSGallery).InstallationPolicy -ne "Trusted") {
     Set-PSRepository -Name PSGallery -InstallationPolicy "Trusted"
 }

--- a/spec/provisioner/provisioner_spec.rb
+++ b/spec/provisioner/provisioner_spec.rb
@@ -634,6 +634,11 @@ $env:PSModulePath=\"$absoluteModulePaths;${env:PSModulePath}\"
 (\"/tmp/vagrant-dsc-1/modules-0;/tmp/vagrant-dsc-1/modules-1\".Split(\";\") | ForEach-Object { gci -Recurse  $_ | ForEach-Object { Unblock-File  $_.FullName} })
 
 Write-Host \"Ensure Modules\"
+Get-PackageProvider -Name NuGet -ListAvailable -ErrorAction SilentlyContinue -ErrorVariable NuGetError | Out-Null
+if ($NuGetError) {
+    Write-Host \"Install Package Provider Nuget\"
+    Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force | Out-Null
+}
 if ((Get-PSRepository -Name PSGallery).InstallationPolicy -ne \"Trusted\") {
     Set-PSRepository -Name PSGallery -InstallationPolicy \"Trusted\"
 }


### PR DESCRIPTION
The new Install-Module Feature may fail if no nuget is installed in the base box. A code to Install if needed