### PR TITLE
Add flag to fail vagrant run if DSC fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,11 @@ In your Vagrantfile, add the following plugin and configure to your needs:
     # For example, you can set this to "nfs" to use NFS synced folders.
     dsc.synced_folder_type = "nfs"
 
+    # Whether to abort the vagrant run if DSC fails.
+    #
+    # By default, this is false.
+    dsc.abort_vagrant_run_if_dsc_fails = true
+
     # Temporary working directory on the guest machine.
     dsc.temp_dir = "/tmp/vagrant-dsc"
   end

--- a/lib/vagrant-dsc/config.rb
+++ b/lib/vagrant-dsc/config.rb
@@ -74,19 +74,22 @@ module VagrantPlugins
       # Do not override this.
       attr_accessor :expanded_configuration_data_file
 
+      attr_accessor :abort_vagrant_run_if_dsc_fails
+
       def initialize
         super
 
-        @configuration_file       = UNSET_VALUE
-        @configuration_data_file  = UNSET_VALUE
-        @manifests_path           = UNSET_VALUE
-        @configuration_name       = UNSET_VALUE
-        @mof_path                 = UNSET_VALUE
-        @module_path              = UNSET_VALUE
-        @configuration_params     = {}
-        @synced_folder_type       = UNSET_VALUE
-        @temp_dir                 = UNSET_VALUE
-        @module_install           = UNSET_VALUE
+        @configuration_file             = UNSET_VALUE
+        @configuration_data_file        = UNSET_VALUE
+        @manifests_path                 = UNSET_VALUE
+        @configuration_name             = UNSET_VALUE
+        @mof_path                       = UNSET_VALUE
+        @module_path                    = UNSET_VALUE
+        @configuration_params           = {}
+        @synced_folder_type             = UNSET_VALUE
+        @temp_dir                       = UNSET_VALUE
+        @module_install                 = UNSET_VALUE
+        @abort_vagrant_run_if_dsc_fails = UNSET_VALUE
         @logger = Log4r::Logger.new("vagrant::vagrant_dsc")
       end
 
@@ -98,15 +101,16 @@ module VagrantPlugins
         super
 
         # Null checks
-        @configuration_file       = "default.ps1" if @configuration_file == UNSET_VALUE
-        @configuration_data_file  = nil if @configuration_data_file == UNSET_VALUE
-        @module_path              = nil if @module_path == UNSET_VALUE
-        @synced_folder_type       = nil if @synced_folder_type == UNSET_VALUE
-        @temp_dir                 = nil if @temp_dir == UNSET_VALUE
-        @module_install           = nil if @module_install == UNSET_VALUE
-        @mof_path                 = nil if @mof_path == UNSET_VALUE
-        @configuration_name       = File.basename(@configuration_file, File.extname(@configuration_file)) if @configuration_name == UNSET_VALUE
-        @manifests_path           = File.dirname(@configuration_file) if @manifests_path == UNSET_VALUE
+        @configuration_file             = "default.ps1" if @configuration_file == UNSET_VALUE
+        @configuration_data_file        = nil if @configuration_data_file == UNSET_VALUE
+        @module_path                    = nil if @module_path == UNSET_VALUE
+        @synced_folder_type             = nil if @synced_folder_type == UNSET_VALUE
+        @temp_dir                       = nil if @temp_dir == UNSET_VALUE
+        @module_install                 = nil if @module_install == UNSET_VALUE
+        @mof_path                       = nil if @mof_path == UNSET_VALUE
+        @configuration_name             = File.basename(@configuration_file, File.extname(@configuration_file)) if @configuration_name == UNSET_VALUE
+        @manifests_path                 = File.dirname(@configuration_file) if @manifests_path == UNSET_VALUE
+        @abort_vagrant_run_if_dsc_fails = false if @abort_vagrant_run_if_dsc_fails == UNSET_VALUE
 
         # Can't supply them both!
         if (@configuration_file != nil && @mof_path != nil)

--- a/lib/vagrant-dsc/locales/en.yml
+++ b/lib/vagrant-dsc/locales/en.yml
@@ -42,3 +42,5 @@ en:
         "DSC Status is \"Failure\"."
       winrm_authorization_error_recover: |-
         The host terminated the active connection. Try to wait for the completion of DSC.
+      dsc_configuration_failed: |-
+        Executing the DSC failed. Set 'abort_vagrant_run_if_dsc_fails' to false to ignore DSC errors.

--- a/lib/vagrant-dsc/provisioner.rb
+++ b/lib/vagrant-dsc/provisioner.rb
@@ -132,6 +132,7 @@ module VagrantPlugins
         if (get_configuration_status == "Failure")
           @machine.ui.error(I18n.t("failure_status"))
           show_dsc_failure_message
+          fail_vagrant_run_if_requested
         end
       end
 
@@ -154,6 +155,14 @@ module VagrantPlugins
         dsc_error_ps = "Get-WinEvent \"Microsoft-Windows-Dsc/Operational\" | Where-Object {$_.LevelDisplayName -eq \"Error\" -and $_.Message.StartsWith(\"Job $((Get-DscConfigurationStatus).JobId)\" )} | foreach { $_.Message }"
         @machine.communicate.shell.powershell(dsc_error_ps) do |type,data|
           @machine.ui.error(data, prefix: false)
+        end
+      end
+
+      def fail_vagrant_run_if_requested
+        if (@config.abort_vagrant_run_if_dsc_fails)
+          raise DSCError, :dsc_configuration_failed
+        else
+          @machine.ui.info("DSC execution failed. Set 'abort_vagrant_run_if_dsc_fails' to true to make this fail the build.")
         end
       end
 

--- a/spec/provisioner/config_spec.rb
+++ b/spec/provisioner/config_spec.rb
@@ -29,17 +29,18 @@ describe VagrantPlugins::DSC::Config do
 
     before { subject.finalize! }
 
-    its("configuration_file")       { expect = "default.ps1" }
-    its("configuration_data_file")  { expect be_nil }
-    its("manifests_path")           { expect = "." }
-    its("configuration_name")       { expect = "default" }
-    its("mof_path")                 { expect be_nil }
-    its("module_path")              { expect be_nil }
-    its("options")                  { expect = [] }
-    its("configuration_params")     { expect = {} }
-    its("synced_folder_type")       { expect be_nil }
-    its("temp_dir")                 { expect match /^\/tmp\/vagrant-dsc-*/ }
-    its("working_directory")        { expect be_nil }
+    its("configuration_file")             { expect = "default.ps1" }
+    its("configuration_data_file")        { expect be_nil }
+    its("manifests_path")                 { expect = "." }
+    its("configuration_name")             { expect = "default" }
+    its("mof_path")                       { expect be_nil }
+    its("module_path")                    { expect be_nil }
+    its("options")                        { expect = [] }
+    its("configuration_params")           { expect = {} }
+    its("synced_folder_type")             { expect be_nil }
+    its("temp_dir")                       { expect match /^\/tmp\/vagrant-dsc-*/ }
+    its("working_directory")              { expect be_nil }
+    its("abort_vagrant_run_if_dsc_fails") { expect be_false }
   end
 
   describe "derived settings" do

--- a/spec/provisioner/provisioner_spec.rb
+++ b/spec/provisioner/provisioner_spec.rb
@@ -283,6 +283,20 @@ describe VagrantPlugins::DSC::Provisioner do
       subject.wait_for_dsc_completion
     end
 
+    it "should throw on failure if requested" do
+      allow_any_instance_of(Object).to receive(:sleep)
+      allow(guest).to receive(:capability?).with(:wait_for_reboot).and_return(true)
+      allow(communicator).to receive(:shell).and_return(shell)
+      allow(guest).to receive(:capability).with(:wait_for_reboot)
+      allow(subject).to receive(:get_lcm_state).and_return("PendingConfiguration")
+      allow(subject).to receive(:get_configuration_status).and_return("Failure")
+      allow(subject).to receive(:get_guest_powershell_version).and_return("5")
+      expect(subject).to receive(:show_dsc_failure_message)
+      allow(root_config).to receive(:abort_vagrant_run_if_dsc_fails).and_return(true)
+
+      expect{ subject.wait_for_dsc_completion }.to raise_error(VagrantPlugins::DSC::DSCError)
+    end
+
     it "should not get the lcm state if powershell version is 4" do
       allow(guest).to receive(:capability?).with(:wait_for_reboot).and_return(true)
       allow(communicator).to receive(:shell).and_return(shell)


### PR DESCRIPTION
Fixes #46.

Not very happy with the name of the flag - `abort_vagrant_run_if_dsc_fails`, but it was about the best I could come up with. Let me know if you come up with a better name.

Tested against Vagrant 1.9.1.